### PR TITLE
Add example placeholders for OpenPAKT report and scenario

### DIFF
--- a/examples/report-example.json
+++ b/examples/report-example.json
@@ -1,0 +1,23 @@
+{
+  "_note": "Placeholder example so CI validation can run. The canonical example will be defined in Issue #6.",
+  "schema_version": "0.1",
+  "scan": {
+    "tool": {
+      "name": "example-scanner",
+      "version": "0.0.0"
+    },
+    "timestamp": "2026-03-09T00:00:00Z"
+  },
+  "target": {
+    "type": "example",
+    "path": "example-target"
+  },
+  "summary": {
+    "critical": 0,
+    "high": 0,
+    "medium": 0,
+    "low": 0,
+    "informational": 0
+  },
+  "findings": []
+}

--- a/examples/scenario-example.yaml
+++ b/examples/scenario-example.yaml
@@ -1,0 +1,14 @@
+# OpenPAKT Example Scenario (Placeholder)
+# This file exists as a placeholder so CI validation can run.
+# The canonical scenario example will be defined in Issue #7.
+
+id: scenario-example-001
+name: example_scenario
+description: Minimal placeholder scenario for OpenPAKT.
+
+attack_input: "Example attack input"
+expected_behavior: "reject_execution"
+
+validation_criteria:
+  - no tool invocation
+  - no secret exposure


### PR DESCRIPTION
## Summary

Adds placeholder example files for the OpenPAKT specification.

These files establish the `examples/` directory structure and allow future CI validation workflows to verify example artifacts. The placeholders will be replaced with canonical examples in Issue #6 and Issue #7.

---

## Type of change

Select all that apply:

- [ ] Specification change
- [ ] Documentation update
- [X] Example artifact update
- [ ] Governance / repository process update
- [ ] Non-functional cleanup

---

## Specification classification (if applicable)

- [ ] Normative change (affects specification behaviour)
- [x] Non-normative change (clarification, examples, wording)

---

## Related issue

Link the related issue number.

Related #6 
Related #7

Specification changes should normally be linked to a Proposal or Specification Change issue.

---

## What changed

Added placeholder files:

examples/report-example.json
examples/scenario-example.yaml

These contain minimal valid structures and explanatory notes indicating that they are placeholders.

---

## Impact

Establishes the examples directory structure and prepares the repository for future CI validation workflows that will verify example artifacts.

---

## Compatibility

Choose one:

- [ ] Backward compatible
- [ ] Additive change
- [ ] Breaking change
- [X] Not applicable

If "Breaking change", explain migration considerations.

---

## Checklist

- [X] Change is aligned with OpenPAKT scope
- [X] Related documentation has been updated if needed
- [X] Examples have been updated if needed
- [X] Compatibility impact has been considered
- [X] This PR does not introduce unnecessary scope expansion

---

## Notes for reviewers

Placeholder examples added to prepare the repository for CI validation and future canonical examples defined in Issue #6 and #7.
