### PR TITLE
spec(report-schema): add v0.1 OpenPAKT report schema with normative fields and example

### DIFF
--- a/spec/report-schema.md
+++ b/spec/report-schema.md
@@ -5,38 +5,175 @@ Status: Draft
 
 # OpenPAKT — Report Schema
 
-## Overview
+## Purpose
 
-This document defines the **OpenPAKT report schema**, which represents the canonical structure used to describe AI agent security findings.
+This document defines the canonical JSON-serialisable report structure for OpenPAKT scan results.
 
-The report schema enables security scanners to produce portable scan results that can be evaluated by CI systems and integrated into DevSecOps workflows.
+The v0.1 report schema provides a minimal contract that scanners, CI systems, and security dashboards can use to exchange findings consistently.
 
-## Design Goals
+## Scope
 
-The report schema is designed to:
+This document defines:
 
-- represent security findings in a portable format
-- support deterministic CI evaluation
-- remain language-agnostic and tool-agnostic
-- enable interoperability across security scanners
+- report-level metadata
+- scan metadata
+- target metadata
+- summary counts by severity
+- findings array structure
+- optional extensibility and provenance fields
 
-## Specification
+This document does **not** define the full finding taxonomy, severity model semantics, scenario format, or CI policy behaviour. Those are specified in separate OpenPAKT documents.
 
-The report schema defines the structure for:
+## Design goals
 
-- report metadata
-- scanner metadata
-- scan target information
-- findings
-- severity levels
-- evidence and contextual information
+The v0.1 report schema is designed to be:
 
-Detailed schema definitions will be specified in future revisions.
+- minimal for early adoption
+- deterministic for CI evaluation
+- implementation-agnostic
+- straightforward to validate with JSON Schema in future revisions
+- extensible without breaking the core contract
 
-## Examples
+## Normative guidance
 
-Example OpenPAKT reports are available in the `examples/` directory.
+- An OpenPAKT report **MUST** be valid JSON.
+- An OpenPAKT report **MUST** include all required fields defined in this document.
+- Field names **MUST** use `snake_case`.
+- Producers **SHOULD** preserve deterministic key ordering in generated reports.
+- Producers **SHOULD** use RFC 3339 UTC timestamps for `scan.timestamp`.
 
-## Compatibility Considerations
+## Top-level structure
 
-The OpenPAKT report schema is designed to remain compatible with common security reporting formats used in CI environments.
+An OpenPAKT v0.1 report has the following top-level fields:
+
+- `schema_version` (required)
+- `scan` (required)
+- `target` (required)
+- `summary` (required)
+- `findings` (required)
+- `metadata` (optional)
+- `provenance` (optional)
+
+## Required and optional fields
+
+### Top-level fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `schema_version` | string | Yes | OpenPAKT schema version implemented by the report (for v0.1, use `"0.1"`). |
+| `scan` | object | Yes | Metadata about the scan run and scanning tool. |
+| `target` | object | Yes | Information about what was scanned. |
+| `summary` | object | Yes | Count of findings by severity level. |
+| `findings` | array | Yes | Zero or more finding objects. |
+| `metadata` | object | No | Additional implementation-agnostic key/value metadata. |
+| `provenance` | object | No | Optional provenance details about report generation and transport context. |
+
+### `scan` object
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `tool` | object | Yes | Scanner identity and version. |
+| `timestamp` | string | Yes | Scan completion timestamp (RFC 3339 UTC recommended). |
+
+### `scan.tool` object
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Scanner/tool name. |
+| `version` | string | Yes | Scanner/tool version. |
+
+### `target` object
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | string | Yes | Target category (for example `repository`, `agent-config`, `workflow`). |
+| `path` | string | Yes | Target identifier or path as provided by the scanner. |
+
+### `summary` object
+
+All fields below are required integer counters.
+
+| Field |
+|---|
+| `critical` |
+| `high` |
+| `medium` |
+| `low` |
+| `informational` |
+
+`summary` values **MUST** exactly match the severity distribution of entries in `findings`.
+
+### `findings` array
+
+Each item in `findings` is a finding object.
+
+A finding object includes the following fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Stable identifier for the finding instance. |
+| `type` | string | Yes | Finding category identifier. |
+| `severity` | string | Yes | Severity value (`critical`, `high`, `medium`, `low`, or `informational`). |
+| `component` | string | Yes | Component, file, or logical unit where the finding applies. |
+| `description` | string | Yes | Human-readable summary of the issue. |
+| `evidence` | object | Yes | Supporting evidence for the finding. |
+| `context` | object | No | Additional structured context useful for triage. |
+| `references` | array | No | Related links or identifiers relevant to the finding. |
+| `metadata` | object | No | Additional implementation-agnostic key/value metadata. |
+
+### `evidence` object
+
+The evidence object is intentionally minimal in v0.1.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `summary` | string | Yes | Short evidence statement supporting the finding. |
+| `location` | string | No | Optional location hint (file path, line span, or logical location). |
+| `snippet` | string | No | Optional raw excerpt or snippet. |
+
+## Compact example
+
+```json
+{
+  "schema_version": "0.1",
+  "scan": {
+    "tool": {
+      "name": "detektor",
+      "version": "0.1.0"
+    },
+    "timestamp": "2026-03-08T10:00:00Z"
+  },
+  "target": {
+    "type": "agent-config",
+    "path": "agent-config.yaml"
+  },
+  "summary": {
+    "critical": 0,
+    "high": 1,
+    "medium": 0,
+    "low": 0,
+    "informational": 0
+  },
+  "findings": [
+    {
+      "id": "finding-001",
+      "type": "unsafe-tool-execution",
+      "severity": "high",
+      "component": "agent-config.yaml",
+      "description": "Tool execution lacks command allow-list constraints.",
+      "evidence": {
+        "summary": "No explicit allow-list found for shell tool invocation.",
+        "location": "agent-config.yaml:12-18"
+      }
+    }
+  ],
+  "provenance": {
+    "generator": "detektor-cli",
+    "run_id": "ci-run-1842"
+  }
+}
+```
+
+## Future compatibility notes
+
+Future OpenPAKT versions may expand finding taxonomy definitions, severity semantics, and CI policy integration rules while preserving the core v0.1 report envelope.


### PR DESCRIPTION
### Motivation

- Provide a canonical, JSON-serialisable v0.1 report envelope to enable consistent interchange of scanner results.
- Define a minimal, deterministic contract for CI evaluation and interoperability between scanners, CI systems, and dashboards.
- Add prescriptive guidance and an example to make it straightforward to implement and validate producer output.

### Description

- Replaced the previous overview/design-goals sections with clearer `Purpose`, `Scope`, and `Design goals` framing and added normative guidance (MUST/SHOULD clauses).
- Introduced the v0.1 top-level envelope and listed required and optional top-level fields including `schema_version`, `scan`, `target`, `summary`, `findings`, `metadata`, and `provenance`.
- Specified detailed object shapes for `scan`/`scan.tool`, `target`, `summary` (severity counters), `findings`, and the minimal `evidence` object with required field types and semantics.
- Added a compact JSON example demonstrating a valid v0.1 report and a short future-compatibility note for subsequent schema evolution.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1366f4894832d8a6de54296e440d1)