### PR TITLE
Require summary counts to match findings severity distribution

### DIFF
--- a/spec/report-schema.md
+++ b/spec/report-schema.md
@@ -101,7 +101,9 @@ All fields below are required integer counters.
 | `low` |
 | `informational` |
 
-`summary` values **SHOULD** match the severity distribution of entries in `findings`.
+`summary` values **MUST** match the severity distribution of entries in `findings`.
+
+If any `summary` counter differs from the number of findings with the corresponding `severity`, the report is invalid.
 
 ### `findings` array
 


### PR DESCRIPTION
## Summary

This PR fixes a specification consistency issue discovered during review of the
OpenPAKT report schema.

The previous wording allowed the `summary` section to only *SHOULD* match the
severity distribution of `findings`. This could allow internally inconsistent
reports (e.g. `summary.high = 0` while a `high` finding exists), which would
lead to different CI outcomes depending on whether consumers trusted `summary`
or recomputed the values.

This PR strengthens the requirement so that the `summary` counts MUST match the
severity distribution of the `findings` array.

---

## Type of change

- [x] Specification change
- [ ] Documentation update
- [ ] Example artifact update
- [ ] Governance / repository process update
- [ ] Non-functional cleanup

---

## Specification classification

- [x] Normative change
- [ ] Non-normative change

---

## Related issue

Follow-up to #1

---

## What changed

- strengthened the requirement for `summary` consistency
- defined `summary` as a derived aggregate of `findings`
- clarified that mismatched reports are non-conformant

---

## Impact

This change ensures deterministic CI evaluation and prevents inconsistent
report interpretations between different OpenPAKT consumers.

---

## Compatibility

- [x] Backward compatible
- [ ] Breaking change

---

## Validation

- reviewed for consistency with OpenPAKT v0.1 scope
- no expansion of specification surface