### PR TITLE
Polish OpenPAKT report schema wording

### DIFF
--- a/spec/report-schema.md
+++ b/spec/report-schema.md
@@ -74,7 +74,7 @@ An OpenPAKT v0.1 report has the following top-level fields:
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `tool` | object | Yes | Scanner identity and version. |
-| `timestamp` | string | Yes | Scan completion timestamp (RFC 3339 UTC recommended). |
+| `timestamp` | string | Yes | Scan completion timestamp. |
 
 ### `scan.tool` object
 
@@ -88,7 +88,7 @@ An OpenPAKT v0.1 report has the following top-level fields:
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `type` | string | Yes | Target category (for example `repository`, `agent-config`, `workflow`). |
-| `path` | string | Yes | Target identifier or path as provided by the scanner. |
+| `path` | string | Yes | Target identifier or path as reported by the scanner. |
 
 ### `summary` object
 
@@ -125,6 +125,8 @@ A finding object includes the following fields:
 | `context` | object | No | Additional structured context useful for triage. |
 | `references` | array | No | Related URLs, document references, or external identifiers relevant to the finding. |
 | `metadata` | object | No | Additional implementation-agnostic key/value metadata. |
+
+Severity values correspond to the OpenPAKT severity model defined in the severity specification.
 
 ### `evidence` object
 


### PR DESCRIPTION
## Summary

This PR applies a small polish pass to the OpenPAKT v0.1 report schema document.

The changes improve wording precision and section consistency without expanding the scope of the specification. In particular, this PR clarifies timestamp requirements, refines `summary` conformance language, and makes the `summary` field definitions consistent with the rest of the document.

---

## Type of change

- [x] Specification change
- [ ] Documentation update
- [ ] Example artifact update
- [ ] Governance / repository process update
- [ ] Non-functional cleanup

---

## Specification classification

- [x] Normative change
- [ ] Non-normative change

---

## Related issue

Follow-up to #1

---

## What changed

- clarified RFC 3339 requirements for `scan.timestamp`
- softened key-ordering guidance so it does not affect conformance
- refined the `summary` section to define it as a derived aggregate of `findings`
- replaced the `summary` field list with a full field-definition table
- clarified that mismatched summary counts are non-conformant
- explicitly stated that valid reports may contain zero findings

---

## Impact

This improves precision and readability of the v0.1 report schema while preserving the same minimal report contract.

It also reduces ambiguity for implementers and reviewers by making conformance language more consistent.

---

## Compatibility

- [x] Backward compatible
- [ ] Breaking change

---

## Validation

- reviewed for consistency with OpenPAKT v0.1 scope
- no new schema surface added
- no expansion into taxonomy, severity semantics, or CI policy behaviour