### PR TITLE
#6 Add canonical OpenPAKT v0.1 report example

### DIFF
--- a/examples/report-example.json
+++ b/examples/report-example.json
@@ -9,7 +9,7 @@
   },
   "target": {
     "type": "workflow",
-    "path": ".github/workflows/agent-review.yml"
+    "path": "ci/agent-review-workflow.yaml"
   },
   "summary": {
     "critical": 1,
@@ -24,11 +24,11 @@
       "type": "prompt_injection",
       "severity": "high",
       "component": "steps.review_prompt",
-      "description": "Untrusted issue content is inserted directly into the agent prompt without isolation or instruction boundary checks.",
+      "description": "Untrusted task content is inserted directly into the agent prompt without isolation or instruction boundary checks.",
       "evidence": {
-        "summary": "Prompt template concatenates user-controlled issue body into system-level instructions.",
-        "location": ".github/workflows/agent-review.yml:42-56",
-        "snippet": "review_prompt: |\n  You are the release assistant.\n  {{ github.event.issue.body }}"
+        "summary": "Prompt template concatenates user-provided task text into high-trust instructions.",
+        "location": "ci/agent-review-workflow.yaml:42-56",
+        "snippet": "review_prompt: |\n  You are the release assistant.\n  {{ input.task_text }}"
       }
     },
     {
@@ -39,7 +39,7 @@
       "description": "The agent can invoke destructive shell commands without an explicit allow-list or approval gate.",
       "evidence": {
         "summary": "Shell tool is enabled with unrestricted command execution in CI context.",
-        "location": ".github/workflows/agent-review.yml:72-88",
+        "location": "ci/agent-review-workflow.yaml:72-88",
         "snippet": "tools:\n  shell:\n    enabled: true\n    allowlist: []"
       }
     }


### PR DESCRIPTION
## Summary

This PR adds the canonical OpenPAKT report example.

The example demonstrates how an OpenPAKT-compatible scanner can produce a report containing scan metadata, target information, severity summaries, and multiple findings. It provides a concrete reference artifact to help implementers understand the expected report structure defined in the specification.

---

## Type of change

Select all that apply:

- [ ] Specification change
- [x] Documentation update
- [x] Example artifact update
- [ ] Governance / repository process update
- [ ] Non-functional cleanup

---

## Specification classification (if applicable)

- [ ] Normative change (affects specification behaviour)
- [x] Non-normative change (clarification, examples, wording)

---

## Related issue

Link the related issue number.

Closes #6

Specification changes should normally be linked to a Proposal or Specification Change issue.

---

## What changed

- added `examples/report-example.json`
- created a canonical OpenPAKT report example aligned with the current report schema
- demonstrated realistic findings including prompt injection and unauthorized tool execution
- included scan metadata, target metadata, severity summary, and evidence fields

---

## Impact

This example improves specification clarity by showing how OpenPAKT findings are represented in a real report structure.

It provides a reference artifact for scanner developers and helps ensure consistent report formatting across implementations. The example can also be used as a reference for future tooling, CI validation tests, and documentation.

---

## Compatibility

Choose one:

- [x] Backward compatible
- [ ] Additive change
- [ ] Breaking change
- [ ] Not applicable

If "Breaking change", explain migration considerations.

---

## Checklist

- [x] Change is aligned with OpenPAKT scope
- [x] Related documentation has been updated if needed
- [x] Examples have been updated if needed
- [x] Compatibility impact has been considered
- [x] This PR does not introduce unnecessary scope expansion

---

## Notes for reviewers

This example is intentionally minimal and designed to remain aligned with the OpenPAKT v0.1 scope. The goal is to provide a clear, canonical reference report without introducing additional fields or expanding the current specification contract.