### PR TITLE
#3 Define OpenPAKT v0.1 severity model

### DIFF
--- a/spec/severity.md
+++ b/spec/severity.md
@@ -5,31 +5,106 @@ Status: Draft
 
 # OpenPAKT — Severity Model
 
-## Overview
+## Purpose
 
-This document defines the **severity model** used to represent the impact and urgency of security findings in OpenPAKT reports.
+This document defines the canonical severity model for OpenPAKT findings.
 
-The severity model enables CI systems to consistently interpret and evaluate security findings produced by different tools.
+The severity model provides a stable, implementation-agnostic way to represent the impact and urgency of a finding across scanners, CI systems, and downstream consumers.
 
-## Design Goals
+## Scope
 
-The severity model is designed to:
+This document defines:
 
-- support deterministic CI policy enforcement
-- provide consistent interpretation of security findings
-- remain simple and implementation-agnostic
-- allow mapping from vendor-specific severity systems
+- canonical OpenPAKT v0.1 severity levels
+- required representation of severity values in findings
+- minimal guidance for vendor severity mapping
+- stability expectations for cross-version CI usage
 
-## Specification
+This document does **not** define taxonomy categories, report object structure, CI policy semantics, or vendor scoring formulas.
 
-The severity model defines a set of standardised severity levels used in OpenPAKT findings.
+## Design goals
 
-Detailed definitions and evaluation semantics will be defined in future revisions.
+The v0.1 severity model is designed to be:
+
+- minimal for MVP adoption
+- deterministic for CI policy evaluation
+- stable across specification versions
+- implementation-agnostic
+- compatible with common external severity systems
+
+## Normative guidance
+
+- A finding `severity` value in interoperable OpenPAKT output **MUST** be one of the canonical severity levels defined in this document.
+- Producers **MUST** emit severity values as lowercase strings.
+- Producers **MUST NOT** emit numeric-only severity values in place of canonical OpenPAKT severity strings.
+- Producers **MAY** retain vendor-native severity values in supplementary metadata, provided the canonical OpenPAKT `severity` remains present and authoritative.
+- Consumers and CI evaluators **MUST** interpret canonical severity levels deterministically for policy evaluation.
+- Severity values **MUST** represent impact and urgency of the finding, independent of scanner-specific naming conventions.
+
+## Canonical severity levels
+
+OpenPAKT v0.1 defines the following canonical severity levels for finding `severity`:
+
+- `critical`
+- `high`
+- `medium`
+- `low`
+- `informational`
+
+These levels are ordered from highest to lowest severity:
+
+`critical` > `high` > `medium` > `low` > `informational`
+
+The canonical level names are stable identifiers for OpenPAKT and are intended to remain consistent across specification versions so CI thresholds remain valid over time.
+
+## Vendor mapping guidance
+
+Security scanners often use vendor-specific labels, numeric scales, or mixed models.
+
+To preserve interoperability:
+
+- Producers **SHOULD** map vendor-native severity models to the canonical OpenPAKT severity levels when generating OpenPAKT findings.
+- Producers **MAY** include original vendor severity values in metadata for traceability.
+- Consumers **SHOULD** evaluate OpenPAKT findings using the canonical severity only.
+
+OpenPAKT v0.1 intentionally does not define mandatory per-vendor mapping tables.
+
+This model is designed to remain compatible with SARIF and similar ecosystems by using a small, stable normalized severity set without prescribing tool-specific conversion logic.
 
 ## Examples
 
-Examples demonstrating severity usage are included in the OpenPAKT report examples located in the `examples/` directory.
+### YAML finding example
 
-## Compatibility Considerations
+```yaml
+id: finding-001
+type: prompt_injection
+severity: high
+component: agent.prompt
+description: Agent followed malicious instructions embedded in retrieved content.
+evidence:
+  summary: Tool call was triggered by attacker-controlled context.
+```
 
-The severity model is designed to support mapping to other security reporting formats commonly used in DevSecOps workflows.
+### CI threshold style example
+
+```txt
+fail-on: high
+```
+
+Expected deterministic behaviour for `fail-on: high`:
+
+- `critical` -> fail build
+- `high` -> fail build
+- `medium` -> report without failing build
+- `low` -> report without failing build
+- `informational` -> report without failing build
+
+## Out of scope
+
+The following are out of scope for this document:
+
+- finding taxonomy definitions
+- report schema field definitions
+- CI policy language and pass/fail semantics
+- numeric scoring models (for example CVSS-like formulas)
+- vendor-specific risk formulas or weighting logic


### PR DESCRIPTION
## Summary

This pull request adds the draft OpenPAKT v0.1 severity model specification.

The purpose of this change is to define a normalized and deterministic severity model for OpenPAKT findings so CI systems and compatible scanners can evaluate results consistently. This continues the core v0.1 specification work alongside the report schema and finding taxonomy.

---

## Type of change

Select all that apply:

- [x] Specification change
- [ ] Documentation update
- [ ] Example artifact update
- [ ] Governance / repository process update
- [ ] Non-functional cleanup

---

## Specification classification (if applicable)

- [x] Normative change (affects specification behaviour)
- [ ] Non-normative change (clarification, examples, wording)

---

## Related issue

Link the related issue number.

Closes #3

Specification changes should normally be linked to a Proposal or Specification Change issue.

---

## What changed

- added the draft `spec/severity.md` document for OpenPAKT v0.1
- defined the canonical severity levels:
  - `critical`
  - `high`
  - `medium`
  - `low`
  - `informational`
- clarified the role of severity in OpenPAKT findings
- established normative guidance for stable and implementation-agnostic severity usage
- documented minimal vendor mapping guidance for interoperability

---

## Impact

This change provides a normalized severity contract for OpenPAKT findings, which is required for deterministic CI policy evaluation and cross-tool interoperability.

It also improves alignment between the report schema, taxonomy, and future CI policy semantics by ensuring scanners can emit consistent severity values that downstream tooling can evaluate predictably.

---

## Compatibility

Choose one:

- [x] Backward compatible
- [ ] Additive change
- [ ] Breaking change
- [ ] Not applicable

If "Breaking change", explain migration considerations.

---

## Checklist

- [x] Change is aligned with OpenPAKT scope
- [x] Related documentation has been updated if needed
- [ ] Examples have been updated if needed
- [x] Compatibility impact has been considered
- [x] This PR does not introduce unnecessary scope expansion

---

## Notes for reviewers

Reviewer focus:
- confirm severity levels are minimal and stable for v0.1
- confirm the document stays implementation-agnostic and CI-friendly
- confirm no unnecessary scoring model or policy logic has been introduced
- confirm wording remains consistent with the existing report schema and taxonomy drafts